### PR TITLE
Update react-scripts to 0.9.5.

### DIFF
--- a/local-dev/package.json
+++ b/local-dev/package.json
@@ -3,13 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
-    "babel-jest": "^16.0.0",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-react": "^6.16.0",
     "fs-extra": "^0.30.0",
-    "jest": "^16.0.2",
-    "react-scripts": "0.7.0",
-    "react-test-renderer": "^15.3.2",
+    "react-scripts": "0.9.5",
+    "react-test-renderer": "15.4.2",
     "redux-mock-store": "^1.2.1"
   },
   "dependencies": {


### PR DESCRIPTION
Removes now superfluous jest & babel-preset packages.